### PR TITLE
Add rpm scripts and skeleton systemd service file

### DIFF
--- a/scripts/rpm/post-inst.sh
+++ b/scripts/rpm/post-inst.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/scripts/rpm/post-rm.sh
+++ b/scripts/rpm/post-rm.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if getent passwd kolide &>/dev/null; then
+	userdel -r kolide &>/dev/null
+fi
+
+exit 0

--- a/scripts/rpm/pre-inst.sh
+++ b/scripts/rpm/pre-inst.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if ! getent passwd kolide &>/dev/null; then
+	useradd -r -u 379 -U -d /opt/kolide -s /sbin/nologin -c kolide -m kolide
+fi
+
+exit 0

--- a/scripts/rpm/pre-rm.sh
+++ b/scripts/rpm/pre-rm.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/shared/kolide.service
+++ b/shared/kolide.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Kolide Web Interface
+ConditionPathExists=/etc/kolide
+
+[Service]
+User=kolide
+Group=kolide
+OOMScoreAdjust=-1000
+ExecStart=/opt/kolide/bin/kolide --config /etc/kolide/kolide.toml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds a kolide.service file for systemd as well as a system account for kolide:

```
~ # rpm -ql kolide 
/etc/kolide/kolide.toml
/opt/kolide/bin/kolide
/usr/lib/systemd/system/kolide.service
~ # id kolide 
uid=379(kolide) gid=379(kolide) groups=379(kolide)
```