### PR TITLE
Fix errors unmarshalling osquery status/result log JSON

### DIFF
--- a/controller/v1/osquery.go
+++ b/controller/v1/osquery.go
@@ -172,7 +172,7 @@ func OSQLog(c *gin.Context) {
 	}
 
 	if req.Type == "result" {
-		var result osquery.LogResultType
+		var result []osquery.LogResultType
 
 		if err := json.Unmarshal(req.Data, &result); err != nil {
 			helpers.JsonError(c, 500, err)
@@ -182,7 +182,7 @@ func OSQLog(c *gin.Context) {
 		log.Info(result)
 
 	} else if req.Type == "status" {
-		var status osquery.LogStatusType
+		var status []osquery.LogStatusType
 
 		if err := json.Unmarshal(req.Data, &status); err != nil {
 			helpers.JsonError(c, 500, err)

--- a/shared/osquery/osquery.go
+++ b/shared/osquery/osquery.go
@@ -44,12 +44,26 @@ type LogStatusType struct {
 	Message  string `json:"message"`
 }
 
+// OsqueryTimestamp is a type alias used for parsing osquery's timestamp format
+type OsqueryTimestamp time.Time
+
+// UnmarshalJSON is the custom parsing logic for the osquery timestamp format
+func (ot *OsqueryTimestamp) UnmarshalJSON(b []byte) (err error) {
+	if b[0] == '"' && b[len(b)-1] == '"' {
+		b = b[1 : len(b)-1]
+	}
+	var t time.Time
+	t, err = time.Parse("Mon Jan 2 15:04:05 2006 MST", string(b))
+	*ot = OsqueryTimestamp(t)
+	return
+}
+
 // LogResultType is the request json result set
 type LogResultType struct {
 	Name      string      `json:"name"`
 	Id        string      `json:"hostIdentifier"`
 	UnixTime  string      `json:"unixTime"`
-	Timestamp time.Time   `json:"calendarTime"`
+	Timestamp OsqueryTimestamp   `json:"calendarTime"`
 	Results   interface{} `json:"columns"`
 	Action    string      `json:"action"`
 }


### PR DESCRIPTION
With osquery 1.7.4 I was seeing errors like:

```
[Jun 30 13:20:37] ERROR json: cannot unmarshal array into Go value of type osquery.LogResultType
[Jun 30 13:20:37] ERROR json: cannot unmarshal array into Go value of type osquery.LogStatusType
```

This PR fixes those errors.